### PR TITLE
fix: Update excerpt length limit

### DIFF
--- a/src/components/post-card/index.jsx
+++ b/src/components/post-card/index.jsx
@@ -33,6 +33,10 @@ const PostCardDate = styled.p`
 const PostCardExcerpt = styled.p`
     color: ${lightTheme.fontColor};
     margin-top: 8px;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
 `;
 
 const PostCard = ({ post }) => {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -14,7 +14,7 @@ const pageQuery = graphql`
             edges {
                 node {
                     id
-                    excerpt(pruneLength: 200, truncate: true)
+                    excerpt(pruneLength: 120, truncate: true)
                     frontmatter {
                         date(formatString: "YYYY년 MM월 DD일")
                         title


### PR DESCRIPTION
## Description

- 대부분의 서론이 3줄이 넘어가므로 excerpt의 제한 글자수를 200자에서 120자로 변경함.
- 추가로 `-webkit-line-clamp` 속성을 사용하여 3줄이 넘어가면 문자열을 잘라내도록 함.