### PR TITLE
feat: Update markdown font styles

### DIFF
--- a/src/styles/markdown.js
+++ b/src/styles/markdown.js
@@ -3,10 +3,9 @@ import { lightTheme } from "./theme";
 
 const StyledMarkdown = styled.div`
     & {
-        font-size: 1rem;
+        font-size: 1.125rem;
         color: ${lightTheme.fontColor};
-        line-height: 1.6;
-        word-break: keep-all;
+        line-height: 1.7;
         overflow: hidden;
         margin-bottom: 64px;
     }
@@ -26,7 +25,7 @@ const StyledMarkdown = styled.div`
 
     & h1,
     & h2 {
-        font-size: 1.25rem;
+        font-size: 1.5rem;
         margin-top: 1.5rem;
         margin-bottom: 1.5rem;
     }
@@ -35,22 +34,14 @@ const StyledMarkdown = styled.div`
     & h4,
     & h5,
     & h6 {
-        font-size: 1.125rem;
+        font-size: 1.25rem;
         margin-top: 1.5rem;
         margin-bottom: 1.5rem;
     }
 
     @media (max-width: 700px) {
-        & h1,
-        & h2 {
-            font-size: 2rem;
-        }
-
-        & h3,
-        & h4,
-        & h5,
-        & h6 {
-            font-size: 1.25rem;
+        & {
+        font-size: 1rem;
         }
     }
 


### PR DESCRIPTION
- 데스크톱 화면에서 `font-size`를 1.125rem으로 변경하고 `line-height`를 1.7로 변경함.
- header 사이즈를 반응형에서 한 사이즈로 통일함.
- `word-break`속성 제거함.