### PR TITLE
feat: Use -webkit-line-clamp property to hide overflow

### DIFF
--- a/src/components/post-navigator/index.jsx
+++ b/src/components/post-navigator/index.jsx
@@ -41,6 +41,10 @@ const PostTitle = styled.p`
     font-weight: 700;
     color: ${lightTheme.fontColor};
     margin: 0;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
 `;
 
 const PostNavigator = ({ previousPost, nextPost }) => {


### PR DESCRIPTION
## Description

PostTitle의 내용이 길어 줄바꿈이 일어나는 것을 방지하기 위해 ` -webkit-line-clamp` 속성을 사용하여 가리도록 변경함.