### PR TITLE
fix: Use siteMetaDate to import default og image

### DIFF
--- a/gatsby-meta-config.js
+++ b/gatsby-meta-config.js
@@ -3,6 +3,7 @@ module.exports = {
     author: `한종우`,
     greetings: `프론트엔드 엔지니어 한종우입니다.`,
     siteDescription: `프론트엔드 엔지니어 한종우의 기술 블로그입니다.`,
+    defaultOgImage: `/default-og-image.png`,
     siteUrl: `https://thearchivelog.dev`,
     githubUrl: `https://github.com/jongwooo`,
     repo: `jongwooo/blog`,

--- a/src/components/seo/index.jsx
+++ b/src/components/seo/index.jsx
@@ -11,10 +11,9 @@ import { HelmetProvider, Helmet } from "react-helmet-async";
 import { useLocation } from "@reach/router";
 
 import useSiteMetaData from "../../hooks/useSiteMetaData";
-import defaultOgImage from "../../../static/default-og-image.png";
 
 const Seo = ({ description, lang, meta, title }) => {
-    const { siteTitle, author, siteDescription, siteUrl } = useSiteMetaData();
+    const { siteTitle, author, siteDescription, defaultOgImage, siteUrl } = useSiteMetaData();
 
     const metaDescription = description || siteDescription;
     const ogImageUrl = `${siteUrl}${defaultOgImage}`;

--- a/src/hooks/useSiteMetaData.jsx
+++ b/src/hooks/useSiteMetaData.jsx
@@ -10,6 +10,7 @@ const useSiteMetaData = () => {
                         author
                         greetings
                         siteDescription
+                        defaultOgImage
                         siteUrl
                         githubUrl
                         repo


### PR DESCRIPTION
## Description

기존 `og:image`를 `siteMetaData`를 통하여 가져오던 방식으로 되돌림.