### PR TITLE
chore: Add lang attribute to html tag

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -5,3 +5,6 @@
  */
 
 // You can delete this file if you're not using it
+exports.onRenderBody = ({ setHtmlAttributes }) => {
+    setHtmlAttributes({ lang: "ko" });
+};


### PR DESCRIPTION
## Description

[Gatsby Server Rendering APIs](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-ssr/)를 사용하여 `html` tag에 `lang` 속성 추가함.