### PR TITLE
chore: Update site meta configurations

### DIFF
--- a/gatsby-meta-config.js
+++ b/gatsby-meta-config.js
@@ -1,9 +1,9 @@
 module.exports = {
     siteTitle: `아카이브-로그`,
     author: `한종우`,
-    greetings: `프론트엔드 엔지니어 한종우입니다.`,
-    siteDescription: `프론트엔드 엔지니어 한종우의 기술 블로그입니다.`,
-    siteKeywords: `블로그, 기술 블로그, 아카이브-로그, 프론트엔드, 개발자`,
+    greetings: `소프트웨어 엔지니어 한종우입니다.`,
+    siteDescription: `소프트웨어 엔지니어 한종우의 기술 블로그입니다.`,
+    siteKeywords: `블로그, 기술 블로그, 아카이브-로그, 개발자`,
     defaultOgImage: `/default-og-image.png`,
     siteUrl: `https://thearchivelog.dev`,
     githubUrl: `https://github.com/jongwooo`,


### PR DESCRIPTION
## Description

`greetings`, `siteDescription`, `siteKeywords`에서 "프론트엔드" 키워드를 "소프트웨어"로 변경(또는 제거)함.