### PR TITLE
chore: Update react-icons version to v4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-icons": "^4.4.0"
+    "react-icons": "^4.6.0"
   },
   "devDependencies": {
     "prettier": "^2.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5141,7 +5141,7 @@ __metadata:
     prop-types: ^15.8.1
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-icons: ^4.4.0
+    react-icons: ^4.6.0
   languageName: unknown
   linkType: soft
 
@@ -13753,12 +13753,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-icons@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "react-icons@npm:4.4.0"
+"react-icons@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "react-icons@npm:4.6.0"
   peerDependencies:
     react: "*"
-  checksum: dd93a1dcc8ac8a3cf46a2b33e80b586fa967331fa5fcb90d061abf276155a8363a331643e203d67cb9bab4261d00a757da854bcce1fce2c6e4258bf3e33f711b
+  checksum: a08375d4563e381e156d826a8d551dd26c1bf7c424a79139173bf4c8df71e884badd7d4f5fe9faa0d73d18ace265bcc89891b65fd8f808812b1011b612ebbc53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

[react-icons@v4.6.0](https://github.com/react-icons/react-icons/releases/tag/v4.6.0) release에 따라 최신 버전으로 업데이트함.