### PR TITLE
fix: Correct workflow name to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on: pull_request
 
 jobs:
-  lint:
+  build:
     strategy:
       matrix:
         node-version: [ 18.x ]


### PR DESCRIPTION
## Description

`build.yml`에서 잘못 설정한 워크플로우 이름을 build로 올바르게 변경함.