### PR TITLE
chore: Use gatsby-cache@main instead of v1.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 
-      - uses: jongwooo/gatsby-cache@v1.0.0
+      - uses: jongwooo/gatsby-cache@main
 
       - name: Install dependencies
         run: yarn install --immutable


### PR DESCRIPTION
## Description

[gatsby-cache@v1.0.0](https://github.com/jongwooo/gatsby-cache/releases/tag/v1.0.0) 대신 main branch의 action을 사용하도록 변경함.