### PR TITLE
refactor: Rename workflow from build to Integration Tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,4 +1,4 @@
-name: build
+name: Integration Tests
 
 on: pull_request
 


### PR DESCRIPTION
## Description

워크플로우 이름을 `build`에서 `Integration Tests`로 변경함.