### PR TITLE
chore: Update react-icons version to v4.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.6.0"
+    "react-icons": "^4.7.1"
   },
   "devDependencies": {
     "prettier": "^2.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5115,7 +5115,7 @@ __metadata:
     prop-types: ^15.8.1
     react: ^18.2.0
     react-dom: ^18.2.0
-    react-icons: ^4.6.0
+    react-icons: ^4.7.1
   languageName: unknown
   linkType: soft
 
@@ -13484,12 +13484,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-icons@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "react-icons@npm:4.6.0"
+"react-icons@npm:^4.7.1":
+  version: 4.7.1
+  resolution: "react-icons@npm:4.7.1"
   peerDependencies:
     react: "*"
-  checksum: a08375d4563e381e156d826a8d551dd26c1bf7c424a79139173bf4c8df71e884badd7d4f5fe9faa0d73d18ace265bcc89891b65fd8f808812b1011b612ebbc53
+  checksum: ed3cbdc5fc0c4d7d2debf78fdc8c4c80aeacf85a506a9a3c11b1d5922de393ac0a6542012b7fb81761e9280c54d0f26827d50a92b54ec8f0c8e52364d89970b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

[react-icons@v4.7.1](https://github.com/react-icons/react-icons/releases/tag/v4.7.1) release에 따라 최신 버전으로 업데이트함.