### PR TITLE
chore: Use specified version instead of matrix

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,17 +4,14 @@ on: pull_request
 
 jobs:
   build:
-    strategy:
-      matrix:
-        node-version: [ 18.x ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
           cache: yarn
 
       - uses: jongwooo/gatsby-cache@main


### PR DESCRIPTION
## Description

GitHub Actions에서 Node.js 런타임 버전을 `matrix` 대신 `18.x` 만 사용하도록 변경함.
