### PR TITLE
fix: Resolve non-interactive elements warning

### DIFF
--- a/src/components/theme-switch/index.jsx
+++ b/src/components/theme-switch/index.jsx
@@ -6,9 +6,9 @@ import "./style.scss";
 
 const ThemeSwitch = ({ theme, toggleTheme }) => {
     return (
-        <div onClick={() => toggleTheme(theme === DARK ? LIGHT : DARK)}>
+        <button className="theme-switch-wrapper" onClick={() => toggleTheme(theme === DARK ? LIGHT : DARK)}>
             {theme === DARK ? <FiSun className="theme-switch" /> : <CgMoon className="theme-switch" />}
-        </div>
+        </button>
     );
 };
 

--- a/src/components/theme-switch/style.scss
+++ b/src/components/theme-switch/style.scss
@@ -1,7 +1,13 @@
-.theme-switch {
-  color: var(--text-color);
+.theme-switch-wrapper {
+  border: 0;
+  outline: 0;
+  background-color: transparent;
 
-  &:hover {
-    cursor: pointer;
+  .theme-switch {
+    color: var(--text-color);
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 }


### PR DESCRIPTION
## Description

#175 의 _non-interactive elements_ warning은 `button` tag가 아닌 다른 tag에서 `onClick`을 사용해서 발생하는 경고임. 기존의 `div` tag를 `button` tag로 변경하고 `button`의 기본 속성을 제거함.
