### PR TITLE
feat: Set theme switch icon size

### DIFF
--- a/src/components/theme-switch/style.scss
+++ b/src/components/theme-switch/style.scss
@@ -4,6 +4,8 @@
   background-color: transparent;
 
   .theme-switch {
+    width: 1.125rem;
+    height: 1.125rem;
     color: var(--text-color);
 
     &:hover {


### PR DESCRIPTION
## Description

`theme-switch`의 icon size를 `1.125rem`으로 설정함.