### PR TITLE
fix: Remove unnecessary whitespace

### DIFF
--- a/src/components/post-navigator/style.scss
+++ b/src/components/post-navigator/style.scss
@@ -17,11 +17,11 @@
     }
   }
 
-  .post-nav .previous-card {
+  .post-nav.previous-card {
     margin-right: auto;
   }
 
-  .post-nav .next-card {
+  .post-nav.next-card {
     margin-left: auto;
     text-align: right;
   }


### PR DESCRIPTION
## Description

post navigator의 `style.scss`에서 불필요하게 작성된 공백을 제거함.