### PR TITLE
feat: Set line-height for post header title

### DIFF
--- a/src/components/post-header/style.scss
+++ b/src/components/post-header/style.scss
@@ -6,6 +6,7 @@
     color: var(--text-color);
     font-size: 2rem;
     font-weight: 700;
+    line-height: 1.2;
     word-break: keep-all;
   }
 


### PR DESCRIPTION
## Description

모바일 화면에서 두 줄 이상의 제목에 대해 줄간격 설정이 필요하여 post header의 제목에 `line-height` 속성을 추가함.