### PR TITLE
feat: Add word-break property to fix text overflow

### DIFF
--- a/src/layout/style.scss
+++ b/src/layout/style.scss
@@ -10,6 +10,7 @@ html {
 body {
   background-color: var(--background-color) !important;
   font-family: $font-family;
+  word-break: keep-all;
 }
 
 .content {


### PR DESCRIPTION
## Description

`word-break: keep-all;`을 body에 추가하여 단어 단위로 줄바꿈이 일어나도록 변경함.