### PR TITLE
chore: Add image background color option

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -121,6 +121,7 @@ module.exports = {
             resolve: `gatsby-remark-images`,
             options: {
               maxWidth: 590,
+              backgroundColor: "transparent",
               showCaptions: ["title"],
               markdownCaptions: true,
             },


### PR DESCRIPTION
## Description

`gatsby-remark-images` 플러그인에 `backgroundColor`옵션을 추가하여 이미지 배경색을 transparent로 지정함.