### PR TITLE
feat: Reduce post title font size for mobile screens

### DIFF
--- a/src/components/post-header/style.scss
+++ b/src/components/post-header/style.scss
@@ -1,3 +1,5 @@
+@use "./src/styles/_variables" as *;
+
 .post-header-wrapper {
   padding: 1.5rem 1rem;
 
@@ -8,6 +10,12 @@
     font-weight: 700;
     line-height: 1.2;
     word-break: keep-all;
+  }
+
+  @media (max-width: $content-max-width) {
+    .post-header-title {
+      font-size: 1.5rem;
+    }
   }
 
   .post-header-date {


### PR DESCRIPTION
## Description

모바일 화면에서는 post title의 사이즈가 `1.5rem`으로 적용되도록 media query를 추가함.