### PR TITLE
chore: Support grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    groups:
+      gatsby:
+        patterns:
+          - "gatsby*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description

Grouped version update 기능 사용을 위해 관련 설정을 추가함.
https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/
