### PR TITLE
refactor: Replace h1 tag with span tag at ProfileCard

### DIFF
--- a/src/components/profile-card/index.jsx
+++ b/src/components/profile-card/index.jsx
@@ -8,7 +8,7 @@ const ProfileCard = () => {
 
   return (
     <div className="profile-card-wrapper">
-      <h1 className="author">{author}</h1>
+      <span className="author">{author}</span>
       <p className="greetings">{greetings}</p>
       {githubUrl && (
         <a className="social-link" href={githubUrl}>


### PR DESCRIPTION
## Description

Fixes #367 

ProfileCard 컴포넌트의 author를 감싸는 `h1` 태그를 `span` 태그로 변경함.